### PR TITLE
implement fallback image in itemPreview.js

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -144,6 +144,10 @@ router.post("/", auth.required, function(req, res, next) {
         return res.sendStatus(401);
       }
 
+      if (!req.body.item.image) {
+        req.body.item.image = "/placeholder.png";
+      }
+
       var item = new Item(req.body.item);
 
       item.seller = user;

--- a/frontend/src/components/Editor.js
+++ b/frontend/src/components/Editor.js
@@ -52,7 +52,7 @@ class Editor extends React.Component {
       const item = {
         title: this.props.title,
         description: this.props.description,
-        image: this.props.image,
+        image: this.props.image || "/placeholder.png",
         tagList: this.props.tagList,
       };
 

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -30,7 +30,7 @@ const ItemPreview = (props) => {
   };
 
   const addDefaultSrc = (ev) => {
-    ev.target.setAttribute("src", "placeholder.png");
+    ev.target.setAttribute("src", "/placeholder.png");
   }
 
   return (
@@ -41,7 +41,7 @@ const ItemPreview = (props) => {
 
       <img
         alt="item"
-        src={item.image}
+        src={item.image ? item.image : "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
         onError={addDefaultSrc}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,6 @@ const ItemPreview = (props) => {
       className="card bg-dark border-light p-3"
       style={{ borderRadius: "20px" }}
     >
-
       <img
         alt="item"
         src={item.image || placeholder}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -29,16 +29,22 @@ const ItemPreview = (props) => {
     }
   };
 
+  const addDefaultSrc = (ev) => {
+    ev.target.src = "placeholder.png";
+  }
+
   return (
     <div
       className="card bg-dark border-light p-3"
       style={{ borderRadius: "20px" }}
     >
+
       <img
         alt="item"
         src={item.image}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
+        onError={addDefaultSrc}
       />
       <div className="card-body">
         <Link to={`/item/${item.slug}`} className="text-white">

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -17,6 +17,8 @@ const mapDispatchToProps = (dispatch) => ({
     }),
 });
 
+const placeholder = "/placeholder.png";
+
 const ItemPreview = (props) => {
   const item = props.item;
 
@@ -37,7 +39,7 @@ const ItemPreview = (props) => {
 
       <img
         alt="item"
-        src={item.image}
+        src={item.image || placeholder}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -30,7 +30,7 @@ const ItemPreview = (props) => {
   };
 
   const addDefaultSrc = (ev) => {
-    ev.target.src = "placeholder.png";
+    ev.target.setAttribute("src", "placeholder.png");
   }
 
   return (

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -29,10 +29,6 @@ const ItemPreview = (props) => {
     }
   };
 
-  const addDefaultSrc = (ev) => {
-    ev.target.setAttribute("src", "/placeholder.png");
-  }
-
   return (
     <div
       className="card bg-dark border-light p-3"
@@ -41,10 +37,9 @@ const ItemPreview = (props) => {
 
       <img
         alt="item"
-        src={ item.image ? item.image : "/placeholder.png" }
+        src={item.image}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
-        onError={ addDefaultSrc }
       />
       <div className="card-body">
         <Link to={`/item/${item.slug}`} className="text-white">

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -41,10 +41,10 @@ const ItemPreview = (props) => {
 
       <img
         alt="item"
-        src={item.image ? item.image : "/placeholder.png"}
+        src={ item.image ? item.image : "/placeholder.png" }
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
-        onError={addDefaultSrc}
+        onError={ addDefaultSrc }
       />
       <div className="card-body">
         <Link to={`/item/${item.slug}`} className="text-white">


### PR DESCRIPTION
# Description

The requirement was for images that failed to load on the product preview page to be replaced by a placeholder image.
This was accomplished by adding an onError event to img element which would change the src attribute to the default image.
![Screenshot 2022-11-30 121951](https://user-images.githubusercontent.com/29438849/204786480-5587468b-0b00-484a-a27d-e23f7b667644.png)
![Screenshot 2022-11-30 121910](https://user-images.githubusercontent.com/29438849/204786499-1d5d0df8-167e-400b-b7ad-d0733fd9e754.png)
