### PR TITLE
modify /api/items controller to enable filtering based on title query…

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -53,6 +53,10 @@ router.get("/", auth.optional, function(req, res, next) {
     query.tagList = { $in: [req.query.tag] };
   }
 
+  if (typeof req.query.title !== "undefined") {
+    query.title = {$regex: req.query.title}
+  }
+
   Promise.all([
     req.query.seller ? User.findOne({ username: req.query.seller }) : null,
     req.query.favorited ? User.findOne({ username: req.query.favorited }) : null


### PR DESCRIPTION
… value

# Description

Add product filtering support to the API by modifying the /api/items route controller to accept query key 'title' and including the matching value in the mongodb query for items.
